### PR TITLE
Feature: reset if files under watch changed

### DIFF
--- a/tools/hrdb/hrdb.pro
+++ b/tools/hrdb/hrdb.pro
@@ -35,6 +35,7 @@ SOURCES += \
     models/symboltable.cpp \
     models/symboltablemodel.cpp \
     models/targetmodel.cpp \
+    models/filewatcher.cpp \
     transport/dispatcher.cpp \
     ui/addbreakpointdialog.cpp \
     ui/breakpointswidget.cpp \
@@ -73,6 +74,7 @@ HEADERS += \
     models/symboltable.h \
     models/symboltablemodel.h \
     models/targetmodel.h \
+    models/filewatcher.h \
     transport/dispatcher.h \
     transport/remotecommand.h \
     ui/addbreakpointdialog.h \

--- a/tools/hrdb/models/filewatcher.cpp
+++ b/tools/hrdb/models/filewatcher.cpp
@@ -19,7 +19,20 @@ FileWatcher::~FileWatcher()
 
 void FileWatcher::clear()
 {
-    m_pFileSystemWatcher->removePaths(m_pFileSystemWatcher->directories());
+    if(m_pFileSystemWatcher)
+        m_pFileSystemWatcher->removePaths(m_pFileSystemWatcher->directories());
+}
+
+void FileWatcher::addPaths(const QStringList &files)
+{
+    if(m_pFileSystemWatcher)
+        m_pFileSystemWatcher->addPaths(files);
+}
+
+void FileWatcher::addPath(const QString &file)
+{
+    if(m_pFileSystemWatcher)
+        m_pFileSystemWatcher->addPath(file);
 }
 
 void FileWatcher::handleFileChanged(QString path)

--- a/tools/hrdb/models/filewatcher.cpp
+++ b/tools/hrdb/models/filewatcher.cpp
@@ -1,0 +1,29 @@
+#include "filewatcher.h"
+#include <QString>
+#include <QFileSystemWatcher>
+#include <QObject>
+#include "transport/dispatcher.h"
+#include "models/targetmodel.h"
+#include "session.h"
+
+FileWatcher::FileWatcher(const Session* pSession):m_pSession(pSession)
+{
+    m_pFileSystemWatcher=new QFileSystemWatcher();
+    QObject::connect( m_pFileSystemWatcher, &QFileSystemWatcher::fileChanged, this, &FileWatcher::handleFileChanged );
+}
+
+FileWatcher::~FileWatcher()
+{
+    delete m_pFileSystemWatcher;
+}
+
+void FileWatcher::clear()
+{
+    m_pFileSystemWatcher->removePaths(m_pFileSystemWatcher->directories());
+}
+
+void FileWatcher::handleFileChanged(QString path)
+{
+    //@FIXME:nope.
+    ((Session*)m_pSession)->resetEmulator();
+}

--- a/tools/hrdb/models/filewatcher.h
+++ b/tools/hrdb/models/filewatcher.h
@@ -19,6 +19,10 @@ public:
     QFileSystemWatcher* m_pFileSystemWatcher;
 
     void clear();
+
+    void addPaths(const QStringList &files);
+
+    void addPath(const QString &file);
 };
 
 #endif // FILEWATCHER_H

--- a/tools/hrdb/models/filewatcher.h
+++ b/tools/hrdb/models/filewatcher.h
@@ -1,0 +1,24 @@
+#ifndef FILEWATCHER_H
+#define FILEWATCHER_H
+
+#include <QObject>
+
+class QString;
+class QFileSystemWatcher;
+class Session;
+
+class FileWatcher : public QObject
+{
+	Q_OBJECT
+public:
+    FileWatcher(const Session* pSession);
+    ~FileWatcher();
+
+    void handleFileChanged(QString path);
+    const Session* m_pSession;
+    QFileSystemWatcher* m_pFileSystemWatcher;
+
+    void clear();
+};
+
+#endif // FILEWATCHER_H

--- a/tools/hrdb/models/launcher.cpp
+++ b/tools/hrdb/models/launcher.cpp
@@ -46,20 +46,16 @@ bool LaunchHatari(const LaunchSettings& settings, const Session* pSession)
     if (otherArgsText.size() != 0)
         args = otherArgsText.split(" ");
 
-    if (pSession->m_pFileWatcher)
-        pSession->m_pFileWatcher->clear(); //remove all watched files
-
     if (settings.m_watcherActive)
     {
-        if (!pSession->m_pFileWatcher)
-        {
-            //@FIXME:nope.
-            ((Session*)pSession)->m_pFileWatcher=new FileWatcher(pSession);
-        }
+        FileWatcher* pFileWatcher=((Session*)pSession)->createFileWatcherInstance();
+        if (pFileWatcher)
+            pFileWatcher->clear(); //remove all watched files
+
         if(settings.m_watcherFiles.length()>0)
-            pSession->m_pFileWatcher->m_pFileSystemWatcher->addPaths(settings.m_watcherFiles.split(","));
+            pFileWatcher->addPaths(settings.m_watcherFiles.split(","));
         else
-            pSession->m_pFileWatcher->m_pFileSystemWatcher->addPath(settings.m_prgFilename);
+            pFileWatcher->addPath(settings.m_prgFilename);
     }
 
     // First make a temp file for breakpoints etc

--- a/tools/hrdb/models/launcher.h
+++ b/tools/hrdb/models/launcher.h
@@ -25,7 +25,9 @@ public:
     QString m_hatariFilename;
     QString m_prgFilename;          // .prg or TOS file to launch
     QString m_workingDirectory;
+    QString m_watcherFiles;
     QString m_argsTxt;
+    bool m_watcherActive;
 };
 
 // Returns true on success (Qt doesn't offer more options?)

--- a/tools/hrdb/models/session.cpp
+++ b/tools/hrdb/models/session.cpp
@@ -5,10 +5,12 @@
 
 #include "targetmodel.h"
 #include "../transport/dispatcher.h"
+#include "../models/filewatcher.h"
 
 Session::Session() :
     QObject(),
-    m_autoConnect(true)
+    m_autoConnect(true),
+    m_pFileWatcher(nullptr)
 {
     m_pStartupFile = new QTemporaryFile(this);
     m_pLoggingFile = new QTemporaryFile(this);
@@ -38,6 +40,7 @@ Session::~Session()
     m_pLoggingFile->close();
     delete m_pTcpSocket;
     delete m_pTimer;
+    delete m_pFileWatcher;
 }
 
 void Session::Connect()
@@ -114,3 +117,9 @@ void Session::connectTimerCallback()
     }
 }
 
+void Session::resetEmulator()
+{
+    m_pDispatcher->ResetWarm();
+    if (!m_pTargetModel->IsRunning())
+        m_pDispatcher->Run();
+}

--- a/tools/hrdb/models/session.cpp
+++ b/tools/hrdb/models/session.cpp
@@ -120,6 +120,18 @@ void Session::connectTimerCallback()
 void Session::resetEmulator()
 {
     m_pDispatcher->ResetWarm();
+     // This will re-request from Hatari, which should return
+    // an empty symbol table.
+    m_pDispatcher->ReadSymbols();
     if (!m_pTargetModel->IsRunning())
         m_pDispatcher->Run();
+}
+
+FileWatcher* Session::createFileWatcherInstance()
+{
+        if (!m_pFileWatcher)
+        {
+            m_pFileWatcher=new FileWatcher(this);
+        }
+        return m_pFileWatcher;
 }

--- a/tools/hrdb/models/session.cpp
+++ b/tools/hrdb/models/session.cpp
@@ -5,10 +5,12 @@
 
 #include "targetmodel.h"
 #include "../transport/dispatcher.h"
+#include "../models/filewatcher.h"
 
 Session::Session() :
     QObject(),
-    m_autoConnect(true)
+    m_autoConnect(true),
+    m_pFileWatcher(nullptr)
 {
     m_pStartupFile = new QTemporaryFile(this);
     m_pLoggingFile = new QTemporaryFile(this);
@@ -37,6 +39,7 @@ Session::~Session()
     m_pLoggingFile->close();
     delete m_pTcpSocket;
     delete m_pTimer;
+    delete m_pFileWatcher;
 }
 
 void Session::Connect()
@@ -111,3 +114,9 @@ void Session::connectTimerCallback()
     }
 }
 
+void Session::resetEmulator()
+{
+    m_pDispatcher->ResetWarm();
+    if (!m_pTargetModel->IsRunning())
+        m_pDispatcher->Run();
+}

--- a/tools/hrdb/models/session.h
+++ b/tools/hrdb/models/session.h
@@ -76,6 +76,8 @@ public:
 
     void resetEmulator();
 
+    FileWatcher* createFileWatcherInstance();
+
 signals:
     void settingsChanged();
 

--- a/tools/hrdb/models/session.h
+++ b/tools/hrdb/models/session.h
@@ -8,8 +8,10 @@
 class QTcpSocket;
 class QTimer;
 class QTemporaryFile;
+class QFileSystemWatcher;
 class Dispatcher;
 class TargetModel;
+class FileWatcher;
 
 #define VERSION_STRING      "0.006 (Feb 2022)"
 
@@ -53,6 +55,7 @@ public:
     QTcpSocket*     m_pTcpSocket;
     QTemporaryFile* m_pStartupFile;
     QTemporaryFile* m_pLoggingFile;
+    FileWatcher*    m_pFileWatcher;
 
     // Connection data
     Dispatcher*     m_pDispatcher;
@@ -68,6 +71,8 @@ public:
 
     void loadSettings();
     void saveSettings();
+
+    void resetEmulator();
 
 signals:
     void settingsChanged();

--- a/tools/hrdb/models/session.h
+++ b/tools/hrdb/models/session.h
@@ -8,8 +8,10 @@
 class QTcpSocket;
 class QTimer;
 class QTemporaryFile;
+class QFileSystemWatcher;
 class Dispatcher;
 class TargetModel;
+class FileWatcher;
 
 #define VERSION_STRING      "0.006 (Feb 2022)"
 
@@ -55,6 +57,7 @@ public:
     QTcpSocket*     m_pTcpSocket;
     QTemporaryFile* m_pStartupFile;
     QTemporaryFile* m_pLoggingFile;
+    FileWatcher*    m_pFileWatcher;
 
     // Connection data
     Dispatcher*     m_pDispatcher;
@@ -70,6 +73,8 @@ public:
 
     void loadSettings();
     void saveSettings();
+
+    void resetEmulator();
 
 signals:
     void settingsChanged();

--- a/tools/hrdb/models/targetmodel.cpp
+++ b/tools/hrdb/models/targetmodel.cpp
@@ -25,7 +25,7 @@ void TargetChangedFlags::Clear()
 }
 
 TargetModel::TargetModel() :
-	QObject(),
+    QObject(),
     m_bConnected(false),
     m_bRunning(true),
     m_bProfileEnabled(0),
@@ -104,7 +104,7 @@ void TargetModel::SetConfig(uint32_t machineType, uint32_t cpuLevel)
 
 void TargetModel::SetRegisters(const Registers& regs, uint64_t commandId)
 {
-	m_regs = regs;
+    m_regs = regs;
     m_changedFlags.SetChanged(TargetChangedFlags::kRegs);
     emit registersChangedSignal(commandId);
 }

--- a/tools/hrdb/ui/mainwindow.cpp
+++ b/tools/hrdb/ui/mainwindow.cpp
@@ -160,7 +160,7 @@ MainWindow::MainWindow(Session& session, QWidget *parent)
     // Wire up menu appearance
     connect(m_pWindowMenu, &QMenu::aboutToShow, this, &MainWindow::updateWindowMenu);
 
-	// Keyboard shortcuts
+    // Keyboard shortcuts
     new QShortcut(QKeySequence("Ctrl+R"),         this, SLOT(startStopClicked()));
     new QShortcut(QKeySequence("Esc"),            this, SLOT(breakPressed()));
     new QShortcut(QKeySequence("S"),              this, SLOT(singleStepClicked()));
@@ -180,7 +180,7 @@ MainWindow::MainWindow(Session& session, QWidget *parent)
 
 MainWindow::~MainWindow()
 {
-	delete m_pDispatcher;
+    delete m_pDispatcher;
     delete m_pTargetModel;
 }
 
@@ -201,7 +201,7 @@ void MainWindow::startStopChangedSlot()
     if (!isRunning)
     {
         // STOPPED
-		// TODO this is where all windows should put in requests for data
+        // TODO this is where all windows should put in requests for data
         // The Main Window does this and other windows feed from it.
         // NOTE: we assume here that PC is already updated (normally this
         // is done with a notification at the stop)
@@ -267,7 +267,7 @@ void MainWindow::startStopClicked()
 
     if (m_pTargetModel->IsRunning())
         m_pDispatcher->Break();
-	else
+    else
         m_pDispatcher->Run();
 }
 

--- a/tools/hrdb/ui/mainwindow.h
+++ b/tools/hrdb/ui/mainwindow.h
@@ -2,9 +2,9 @@
 #define MAINWINDOW_H
 
 /*
-	Main GUI Window.
+    Main GUI Window.
 
-	Currently everything is controlled and routed through here.
+    Currently everything is controlled and routed through here.
 */
 
 #include <QMainWindow>
@@ -52,7 +52,7 @@ protected:
 
 private slots:
     void connectChangedSlot();
-	void startStopChangedSlot();
+    void startStopChangedSlot();
     void memoryChangedSlot(int slot, uint64_t commandId);
     void runningRefreshTimerSlot();
     void flushSlot(const TargetChangedFlags& flags, uint64_t commandId);
@@ -91,7 +91,7 @@ private:
     void ExceptionsDialogTriggered();
     void PrefsDialogTriggered();
 
-	// Populaters
+    // Populaters
     void PopulateRunningSquare();
     void updateButtonEnable();
 
@@ -101,10 +101,10 @@ private:
 
     // Our UI widgets
     QWidget*        m_pRunningSquare;
-    QPushButton*	m_pStartStopButton;
-    QPushButton*	m_pStepIntoButton;
-    QPushButton*	m_pStepOverButton;
-    QPushButton*	m_pRunToButton;
+    QPushButton*    m_pStartStopButton;
+    QPushButton*    m_pStepIntoButton;
+    QPushButton*    m_pStepOverButton;
+    QPushButton*    m_pRunToButton;
     QComboBox*      m_pRunToCombo;
 
     RegisterWidget* m_pRegisterWidget;
@@ -125,7 +125,7 @@ private:
 
     // Low-level data
     Session&                    m_session;
-    Dispatcher*             	m_pDispatcher;
+    Dispatcher*                 m_pDispatcher;
     TargetModel*                m_pTargetModel;
 
     // Target data -- used for single-stepping

--- a/tools/hrdb/ui/rundialog.cpp
+++ b/tools/hrdb/ui/rundialog.cpp
@@ -73,8 +73,8 @@ RunDialog::RunDialog(QWidget *parent, Session* pSession) :
     m_pExecutableTextEdit = new QLineEdit("hatari", this);
     m_pArgsTextEdit = new QLineEdit("", this);
     m_pPrgTextEdit = new QLineEdit("", this);
-	m_pWorkingDirectoryTextEdit = new QLineEdit("", this);
-	m_pWatcherFilesTextEdit = new QLineEdit(this);
+    m_pWorkingDirectoryTextEdit = new QLineEdit("", this);
+    m_pWatcherFilesTextEdit = new QLineEdit(this);
     m_pWatcherFilesTextEdit->setPlaceholderText("<watch run programm/image>");
 
     m_pBreakModeCombo = new QComboBox(this);
@@ -131,9 +131,9 @@ RunDialog::RunDialog(QWidget *parent, Session* pSession) :
     connect(pExeButton, &QPushButton::clicked, this, &RunDialog::exeClicked);
     connect(pPrgButton, &QPushButton::clicked, this, &RunDialog::prgClicked);
     connect(pWDButton, &QPushButton::clicked, this, &RunDialog::workingDirectoryClicked);
-	connect(pWatcherButton, &QPushButton::clicked, this, &RunDialog::watcherFilesClicked);
-	connect(m_pWatcherFilesTextEdit, &QLineEdit::textChanged, this, &RunDialog::watcherTextChanged);
-	connect(m_pWatcherCheckBox, &QCheckBox::stateChanged, this, &RunDialog::watcherActiveChanged);
+    connect(pWatcherButton, &QPushButton::clicked, this, &RunDialog::watcherFilesClicked);
+    connect(m_pWatcherFilesTextEdit, &QLineEdit::textChanged, this, &RunDialog::watcherTextChanged);
+    connect(m_pWatcherCheckBox, &QCheckBox::stateChanged, this, &RunDialog::watcherActiveChanged);
     connect(pOkButton, &QPushButton::clicked, this, &RunDialog::okClicked);
     connect(pCancelButton, &QPushButton::clicked, this, &RunDialog::reject);
     loadSettings();

--- a/tools/hrdb/ui/rundialog.h
+++ b/tools/hrdb/ui/rundialog.h
@@ -6,6 +6,7 @@
 #include "../models/launcher.h"
 
 class QLineEdit;
+class QCheckBox;
 class QComboBox;
 class TargetModel;
 class Dispatcher;
@@ -28,6 +29,9 @@ private slots:
     void exeClicked();
     void prgClicked();
     void workingDirectoryClicked();
+    void watcherFilesClicked();
+    void watcherTextChanged();
+    void watcherActiveChanged();
 
 private:
     // Settings
@@ -42,6 +46,8 @@ private:
     QLineEdit*      m_pPrgTextEdit;
     QLineEdit*      m_pArgsTextEdit;
     QLineEdit*      m_pWorkingDirectoryTextEdit;
+    QLineEdit*      m_pWatcherFilesTextEdit;
+    QCheckBox*      m_pWatcherCheckBox; 
     QComboBox*      m_pBreakModeCombo;
 
     // Current temporary settings to launch with


### PR DESCRIPTION
This automagically resets the emulation in Hatari if the debugged binary (or: any given file under watch) changes. Heads up: symbols aren't handled in a gracefull way atm - as in: they are not re-loaded from the new binary; so symbol handling still needs some thought for this to be ready for prime-time, but the feature is pretty helpful as-is, still.