### PR TITLE
MacOS sanity fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,10 @@ else()
 endif(APPLE)
 
 if(ENABLE_OSX_BUNDLE)
+	add_custom_target(clean_frameworks ALL
+		COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/cmake/RemoveFrameworks.cmake
+		COMMENT "Removing old Frameworks directory before build")
+
 	set(APP_NAME "Hatari")
 else()
 	set(APP_NAME "hatari")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if(APPLE AND CMAKE_BUILD_TYPE STREQUAL "Release")
     set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "Target architectures")
   endif()
 
-  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Target minimum macOS version")
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14" CACHE STRING "Target macOS Mojave (2018) or newer")
 endif()
 
 project(Hatari C)

--- a/cmake/RemoveFrameworks.cmake
+++ b/cmake/RemoveFrameworks.cmake
@@ -1,0 +1,7 @@
+set(FRAMEWORKS_PATH "${CMAKE_SOURCE_DIR}/src/Hatari.app/Contents/Frameworks")
+
+if (EXISTS "${FRAMEWORKS_PATH}")
+    execute_process(COMMAND /bin/chmod -R u+w "${FRAMEWORKS_PATH}")
+    file(REMOVE_RECURSE "${FRAMEWORKS_PATH}")
+endif()
+


### PR DESCRIPTION
Down the rabbit hole we go!

This one consists of two commits:

- There is no reason whatsoever to support MacOS 10.9 from 2013! This one adds a very conservative bump to a minimum of 10.13 from 2018 (current version at time of writing is 15.3)
- There is a snafu with a half built application bundle due to unfinished cmake scripts. Instead of having to manually force delete the application bundle for each build, lets just remove it as it is always repopulated anyway.