### PR TITLE
Left/right moves disassembly the minimum number of bytes

### DIFF
--- a/tools/hrdb/docs/KEYS.md
+++ b/tools/hrdb/docs/KEYS.md
@@ -53,6 +53,7 @@ Disassembly focus
 | Key           | Operation                           |
 |---------------|-------------------------------------|
 | Up/Down       | Move Cursor                         |
+| Left/Right    | Move up/down by one CPU/DSP word    |
 | Page Up/Down  | Move by several lines               |
 | Ctrl+B        | Toggle breakpoint (cursor position) |
 | Ctrl+F        | Search for text/hexadecimal string  |

--- a/tools/hrdb/ui/disasmwidget.cpp
+++ b/tools/hrdb/ui/disasmwidget.cpp
@@ -327,6 +327,20 @@ void DisasmWidget::PageDown()
     }
 }
 
+void DisasmWidget::MoveUpMin()
+{
+    // Move up the minimum instruction size (when not crossing 0)
+    int32_t nextUpPosition = m_logicalAddr -  m_minInstSize;
+    if (nextUpPosition >= 0)
+        SetAddress(nextUpPosition);
+}
+
+void DisasmWidget::MoveDownMin()
+{
+    // Move down the minimum instruction size
+    SetAddress(m_logicalAddr + m_minInstSize);
+}
+
 void DisasmWidget::MouseScrollUp()
 {
     if (m_requestId != 0)
@@ -667,6 +681,8 @@ void DisasmWidget::keyPressEvent(QKeyEvent* event)
             {
             case Qt::Key_Up:         MoveUp();              return;
             case Qt::Key_Down:       MoveDown();            return;
+            case Qt::Key_Left:       MoveUpMin();           return;
+            case Qt::Key_Right:      MoveDownMin();         return;
             case Qt::Key_PageUp:     PageUp();              return;
             case Qt::Key_PageDown:   PageDown();            return;
             case Qt::Key_F9:         toggleBreakpoint();    return;
@@ -1701,6 +1717,16 @@ void DisasmWindow::keyDownPressed()
 void DisasmWindow::keyUpPressed()
 {
     m_pDisasmWidget->MoveUp();
+}
+
+void DisasmWindow::keyLeftPressed()
+{
+    m_pDisasmWidget->MoveUpMin();
+}
+
+void DisasmWindow::keyRightPressed()
+{
+    m_pDisasmWidget->MoveDownMin();
 }
 
 void DisasmWindow::keyPageDownPressed()

--- a/tools/hrdb/ui/disasmwidget.h
+++ b/tools/hrdb/ui/disasmwidget.h
@@ -40,6 +40,8 @@ public:
     bool SetSearchResultAddress(uint32_t addr);
     void MoveUp();
     void MoveDown();
+    void MoveUpMin();
+    void MoveDownMin();
 
     void PageUp();
     void PageDown();
@@ -288,6 +290,8 @@ protected:
 protected slots:
     void keyDownPressed();
     void keyUpPressed();
+    void keyLeftPressed();
+    void keyRightPressed();
     void keyPageDownPressed();
     void keyPageUpPressed();
 


### PR DESCRIPTION
Inspired by MonST, this patch lets the user change instruction alignment manually by using the left and right arrow keys.